### PR TITLE
Use custom Meteor 1.6.1.1 build of Node 8.11.1.

### DIFF
--- a/galaxy-app/Dockerfile
+++ b/galaxy-app/Dockerfile
@@ -23,5 +23,6 @@ RUN mkdir -p /app/bundle
 # it's OK for setup.sh to install both Node and npm for older versions, but not
 # for us to "cache" older Node versions.
 RUN NODE_VERSION="8.9.4" /app/install_node.sh
+RUN NODE_VERSION="8.11.1" /app/install_node.sh
 
 CMD ["/app/run.sh"]

--- a/galaxy-app/app/install_node.sh
+++ b/galaxy-app/app/install_node.sh
@@ -16,6 +16,13 @@ echo "Installing node version ${NODE_VERSION} to /node-v${NODE_VERSION}-linux-x6
 
 set -x
 
-curl -sSLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C / \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
+if [ "$NODE_VERSION" == "8.11.1" ]
+then
+    # Download the custom build that shipped with Meteor 1.6.1.1:
+    # https://github.com/meteor/node/commits/v8.11.1-meteor
+    NODE_URL="https://s3.amazonaws.com/com.meteor.jenkins/dev-bundle-node-129/node_Linux_x86_64_v8.11.1.tar.gz"
+else
+    NODE_URL="https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"
+fi
+
+curl -sSL "$NODE_URL" | tar -xz -C /


### PR DESCRIPTION
The official Node 8.11.1 still suffers from the segmentation fault problem reported in https://github.com/nodejs/node/issues/19274, because [8.11.0](https://nodejs.org/en/blog/release/v8.11.0/) was a security release that did not include the necessary patch, and [8.11.1](https://nodejs.org/en/blog/release/v8.11.1/) was a release without any additional commits.

To fix the problem in development, Meteor 1.6.1.1 comes with a custom build of Node 8.11.1 with [one additional commit](https://github.com/meteor/node/commits/v8.11.1-meteor). However, Galaxy does not use this custom build of Node 8.11.1, but instead uses the official build, which can lead to segmentation faults in production.

Node 8.10.0 and 8.11.0 also suffer from the segmentation fault problem that was fixed by this custom build, but no version of Meteor has (or will) ever ship with either of those versions of Node, so 8.11.1 is the only Node version we need to worry about.

Issues that should be fixed once this change is deployed:
https://github.com/meteor/meteor/issues/9797
https://meteor.zendesk.com/agent/tickets/12197
https://meteor.zendesk.com/agent/tickets/12195
https://meteor.zendesk.com/agent/tickets/12216
https://meteor.zendesk.com/agent/tickets/12218