### PR TITLE
Allow downloading Node release candidate builds.

### DIFF
--- a/galaxy-app/app/install_node.sh
+++ b/galaxy-app/app/install_node.sh
@@ -21,6 +21,9 @@ then
     # Download the custom build that shipped with Meteor 1.6.1.1:
     # https://github.com/meteor/node/commits/v8.11.1-meteor
     NODE_URL="https://s3.amazonaws.com/com.meteor.jenkins/dev-bundle-node-129/node_Linux_x86_64_v8.11.1.tar.gz"
+elif [[ "$NODE_VERSION" =~ -rc\.[0-9]+$ ]]
+then
+    NODE_URL="https://nodejs.org/download/rc/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"
 else
     NODE_URL="https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"
 fi


### PR DESCRIPTION
[Meteor 1.7](https://github.com/meteor/meteor/pull/9826) is currently in the release candidate phase of testing, and we're aiming to ship when Node 8.11.2 is finalized. In the meantime, it would be great to allow testers to try the latest [Node v8.11.2-rc.1 release](https://nodejs.org/download/rc/v8.11.2-rc.1/), including deploying their apps to Galaxy.