### PR TITLE
Try to extract Node version from star.json before .node_version.txt.

### DIFF
--- a/galaxy-app/app/select_node_version.sh
+++ b/galaxy-app/app/select_node_version.sh
@@ -7,7 +7,7 @@ set -e
 # that works for older versions too.
 
 meteor_star_json="/app/bundle/star.json"
-default="4.9.0" # Works for all 1.4.x and 1.5.x apps.
+default="0.10.46"
 
 get_desired_version() {
   if [ -f "${meteor_star_json}" ]; then

--- a/galaxy-app/app/select_node_version.sh
+++ b/galaxy-app/app/select_node_version.sh
@@ -2,19 +2,30 @@
 
 set -e
 
-# Look up .node_version.txt in Meteor application bundle
-# (available since 1.2), and return the numerical version
-# number of node used to deploy this app. If the file is
-# not found, return a default version that works with
-# really old Meteor distribution.
-# (More recent versions also make it available in star.json
-# alongside the npm version, but we still read from the most
-# compatible place.)
+# Look up nodeVersion from the Meteor application star.json (available
+# since 1.5.2/1.6). If the value is not found, return a default version
+# that works for older versions too.
 
-default="0.10.46"
+meteor_star_json="/app/bundle/star.json"
+default="4.9.0" # Works for all 1.4.x and 1.5.x apps.
 
-if [ -f /app/bundle/.node_version.txt ]; then
-  grep -oh '[0-9\.]*' /app/bundle/.node_version.txt
-else
-  echo "$default"
+get_desired_version() {
+  if [ -f "${meteor_star_json}" ]; then
+    jq -r '.nodeVersion | select (.!=null)' "${meteor_star_json}"
+  fi
+}
+
+desired_version=$(get_desired_version)
+
+if [ -n "${desired_version}" ]; then
+  echo "${desired_version}"
+  exit 0
 fi
+
+# Fall back to the .node_version.txt file if start.json didn't work.
+if [ -f /app/bundle/.node_version.txt ]; then
+  grep -oh '[0-9][0-9\.]*\(-\S*\)\?' /app/bundle/.node_version.txt
+  exit 0
+fi
+
+echo "$default"


### PR DESCRIPTION
If `star.json` doesn't work, fall back to grepping `.node_version.txt`, except with a slightly different grep pattern that should match `-rc.n` versions (without the leading `v` prefix).

Also updated the default version to 4.9.0, which will work for all Meteor 1.4.x and 1.5.x builds.

Follow-up to #3.